### PR TITLE
Set a default PVC for clients starting ESP projects

### DIFF
--- a/single_user_clients/templates/esm/esm.yml
+++ b/single_user_clients/templates/esm/esm.yml
@@ -46,6 +46,8 @@ spec:
           value: "true"
         - name: ESM_LICENSE_FILE
           value: "/opt/sas/viya/config/etc/sysconfig/sas-esm-service/default/license.txt"
+        - name: SAS_ESP_COMMON_KUBERNETES_DEFAULTS_PERSISTENTVOLUMECLAIM
+          value: esp-pv
         - name: SAS_ESP_COMMON_KUBERNETES
           value: "true"
         - name: SAS_ESP_COMMON_KUBERNETES_NAMESPACE


### PR DESCRIPTION
We use SAS_ESP_COMMON_KUBERNETES_DEFAULTS_PERSISTENTVOLUMECLAIM to set a default PVC from clients when starting projects (through creation of an ESPServer CR)