### PR TITLE
Set a default PVC for clients starting ESP projects

### DIFF
--- a/single_user_clients/templates/espstudio/espstudio.yml
+++ b/single_user_clients/templates/espstudio/espstudio.yml
@@ -41,7 +41,9 @@ spec:
         - name: SAS_ESP_COMMON_KUBERNETES
           value: "true"
         - name: SAS_ESP_COMMON_KUBERNETES_NAMESPACE
-          value: TEMPLATE_ESP_NAMESPACE 
+          value: TEMPLATE_ESP_NAMESPACE
+        - name: SAS_ESP_COMMON_KUBERNETES_DEFAULTS_PERSISTENTVOLUMECLAIM
+          value: esp-pv
         volumeMounts:
            - mountPath: /mnt/data
              name: data


### PR DESCRIPTION
We use SAS_ESP_COMMON_KUBERNETES_DEFAULTS_PERSISTENTVOLUMECLAIM to set a default PVC from clients when starting projects (through creation of an ESPServer CR)